### PR TITLE
BUGFIX: no changes emitted when setting values in reactive form with for…

### DIFF
--- a/src/lib/color-picker/color-picker.component.ts
+++ b/src/lib/color-picker/color-picker.component.ts
@@ -261,9 +261,12 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
       if (this._selectedColor !== tmpSelectedColor) {
         this._selectedColor = tmpSelectedColor;
         this.selected.next(this._selectedColor);
+        //finally emit the changes for updating the origin
+        this.change.next(this._selectedColor);
       } else {
         this.selected.emit(this._selectedColor);
       }
+
     }
   }
 
@@ -292,7 +295,9 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
   updateTmpSelectedColor(color: string) {
     if (color) {
       this._tmpSelectedColor.next(color);
-      this.change.next(color);
+
+      //bugfix: no emittance till either confirm clicked or hidden buttons
+      // this.change.next(color);
       if (this._hideButtons) {
         this._updateSelectedColor();
       }

--- a/src/lib/color-picker/color-picker.directives.ts
+++ b/src/lib/color-picker/color-picker.directives.ts
@@ -117,9 +117,11 @@ export class MccColorPickerOriginDirective implements ControlValueAccessor {
   writeValue(color: string) {
     this.renderer.setProperty(this.elementRef.nativeElement, 'value', color);
     this.change.next(color);
-    if (this.propagateChanges) {
-      this.propagateChanges(color);
-    }
+
+    //in write value the view is updated - no propagation needed
+    //if (this.propagateChanges) {
+    //  this.propagateChanges(color);
+    //}
   }
 
   /**


### PR DESCRIPTION
I'm using this nice control in a reactive form and observing this valueChanges. In the current version, the valueChanges are triggered when setting form values via form.setValue even if the option emitEvent is set to false.

This PR fixes this (no Issue raised so far)