### PR TITLE
Fixed bug #71 with Validators of RGB inputs

### DIFF
--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -189,7 +189,7 @@ export class MccColorPickerSelectorComponent
           validators: [
             Validators.min(0),
             Validators.max(256),
-            Validators.minLength(1),
+            Validators.required,
             Validators.maxLength(3),
           ],
           updateOn: 'blur',


### PR DESCRIPTION
Bug #71 
+ using Validators.required instead of Validators.minLength(1).

Known issue and more information about that is available here: https://github.com/angular/angular/issues/23749