### PR TITLE
fix(feature:color-picker): Issue 70 - Fix title color changing on color picker

### DIFF
--- a/src/lib/color-picker/color-picker-selector.component.scss
+++ b/src/lib/color-picker/color-picker-selector.component.scss
@@ -49,7 +49,7 @@ canvas {
 
   &.black {
     color: #100214;
-    label {
+    label.mat-form-field-label {
       color: #100214;
     }
     .mat-form-field-underline {
@@ -58,7 +58,7 @@ canvas {
   }
   &.white {
     color: #ffffff;
-    label {
+    label.mat-form-field-label {
       color: #ffffff;
     }
     .mat-form-field-underline {


### PR DESCRIPTION
A more specific css selector was needed for setting the label color for the material inputs on the color picker.

This adds the class `.mat-form-field-label` to the selector.

https://github.com/tiaguinho/material-community-components/issues/70