### PR TITLE
feat(color-picker): reference svg icon only by name

### DIFF
--- a/src/demo-app/app/color-picker/color-picker.component.html
+++ b/src/demo-app/app/color-picker/color-picker.component.html
@@ -81,7 +81,7 @@
         <td>
           <code>selected_svg_icon: string</code>
         </td>
-        <td class="api-description">Define svg URL icon to be used on selected colors (need HttpClientModule)</td>
+        <td class="api-description">Define SVG icon name to be used on selected colors (nees to be registered in MatIconRegistry). Overrides "selected_icon"</td>
         <td class="api-description">null</td>
       </tr>
       <tr>

--- a/src/lib/color-picker/color-picker-collection.component.spec.ts
+++ b/src/lib/color-picker/color-picker-collection.component.spec.ts
@@ -5,7 +5,14 @@ import { By } from '@angular/platform-browser';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerOptionDirective } from './color-picker.directives';
 import { MccColorPickerService } from './color-picker.service';
-import { DISABLE_SELECTED_COLOR_ICON, ENABLE_ALPHA_SELECTOR, EMPTY_COLOR, SELECTED_COLOR_ICON, USED_COLORS } from './color-picker';
+import {
+  DISABLE_SELECTED_COLOR_ICON,
+  ENABLE_ALPHA_SELECTOR,
+  EMPTY_COLOR,
+  SELECTED_COLOR_ICON,
+  USED_COLORS,
+  SELECTED_COLOR_SVG_ICON
+} from './color-picker';
 
 describe('MccColorPickerCollectionComponent', () => {
   let comp: MccColorPickerCollectionComponent;
@@ -23,6 +30,7 @@ describe('MccColorPickerCollectionComponent', () => {
         { provide: ENABLE_ALPHA_SELECTOR, useValue: false },
         { provide: DISABLE_SELECTED_COLOR_ICON, useValue: false },
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
+        { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none' },
         { provide: USED_COLORS, useValue: [] }
       ]

--- a/src/lib/color-picker/color-picker-collection.component.ts
+++ b/src/lib/color-picker/color-picker-collection.component.ts
@@ -14,11 +14,8 @@ import {
   EMPTY_COLOR,
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
-  SVG_SELECTED_ICON_NAME,
   MccColorPickerOption
 } from './color-picker';
-import { DomSanitizer } from '@angular/platform-browser';
-import { MatIconRegistry } from '@angular/material/icon';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { MccColorPickerService } from './color-picker.service';
 
@@ -106,8 +103,6 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private colorPickerService: MccColorPickerService,
-    private sanitizer: DomSanitizer,
-    private svgRegister: MatIconRegistry,
     @Inject(EMPTY_COLOR) public emptyColor: string,
     @Inject(SELECTED_COLOR_ICON) private selectedColorIcon: string,
     @Inject(SELECTED_COLOR_SVG_ICON) public selectedColorSvgIcon: string,
@@ -124,11 +119,7 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
     if (!this.selectedColorSvgIcon) {
       this._selectedIcon = this.selectedColorIcon;
     } else {
-      this.svgRegister.addSvgIcon(
-        SVG_SELECTED_ICON_NAME,
-        this.sanitizer.bypassSecurityTrustResourceUrl(this.selectedColorSvgIcon)
-      );
-      this._selectedSvgIcon = SVG_SELECTED_ICON_NAME;
+      this._selectedSvgIcon = this.selectedColorSvgIcon;
     }
   }
 

--- a/src/lib/color-picker/color-picker.component.spec.ts
+++ b/src/lib/color-picker/color-picker.component.spec.ts
@@ -14,7 +14,14 @@ import { MccColorPickerCollectionComponent } from './color-picker-collection.com
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
 import { MccColorPickerOptionDirective } from './color-picker.directives';
 import { MccColorPickerService } from './color-picker.service';
-import { EMPTY_COLOR, USED_COLORS, SELECTED_COLOR_ICON, DISABLE_SELECTED_COLOR_ICON, ENABLE_ALPHA_SELECTOR } from './color-picker';
+import {
+  EMPTY_COLOR,
+  USED_COLORS,
+  SELECTED_COLOR_ICON,
+  DISABLE_SELECTED_COLOR_ICON,
+  ENABLE_ALPHA_SELECTOR,
+  SELECTED_COLOR_SVG_ICON
+} from './color-picker';
 
 describe('MccColorPickerComponent', () => {
   let comp: MccColorPickerComponent;
@@ -61,6 +68,7 @@ describe('MccColorPickerComponent', () => {
         { provide: ENABLE_ALPHA_SELECTOR, useValue: false },
         { provide: DISABLE_SELECTED_COLOR_ICON, useValue: false },
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
+        { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none' },
         { provide: USED_COLORS, useValue: [] },
         { provide: ComponentFixtureAutoDetect, useValue: true },

--- a/src/lib/color-picker/color-picker.directive.spec.ts
+++ b/src/lib/color-picker/color-picker.directive.spec.ts
@@ -18,7 +18,14 @@ import {
   MccColorPickerOriginDirective,
   MccColorPickerOptionDirective
 } from './color-picker.directives';
-import { DISABLE_SELECTED_COLOR_ICON, ENABLE_ALPHA_SELECTOR, EMPTY_COLOR, SELECTED_COLOR_ICON, USED_COLORS } from './color-picker';
+import {
+  DISABLE_SELECTED_COLOR_ICON,
+  ENABLE_ALPHA_SELECTOR,
+  EMPTY_COLOR,
+  SELECTED_COLOR_ICON,
+  USED_COLORS,
+  SELECTED_COLOR_SVG_ICON
+} from './color-picker';
 
 //
 @Component({
@@ -77,6 +84,7 @@ describe('MccConnectedColorPickerdirective', () => {
         { provide: ENABLE_ALPHA_SELECTOR, useValue: false },
         { provide: DISABLE_SELECTED_COLOR_ICON, useValue: false },
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
+        { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none'},
         { provide: USED_COLORS, useValue: [] }
       ]

--- a/src/lib/color-picker/color-picker.service.spec.ts
+++ b/src/lib/color-picker/color-picker.service.spec.ts
@@ -1,7 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { MccColorPickerService } from './color-picker.service';
-import { DISABLE_SELECTED_COLOR_ICON, ENABLE_ALPHA_SELECTOR, EMPTY_COLOR, SELECTED_COLOR_ICON, USED_COLORS } from './color-picker';
-import { doesNotThrow } from 'assert';
+import {
+  DISABLE_SELECTED_COLOR_ICON,
+  ENABLE_ALPHA_SELECTOR,
+  EMPTY_COLOR,
+  SELECTED_COLOR_ICON,
+  USED_COLORS,
+  SELECTED_COLOR_SVG_ICON
+} from './color-picker';
 
 describe('MccColorPickerService', () => {
   const color = '#FFFFFF';
@@ -13,6 +19,7 @@ describe('MccColorPickerService', () => {
         { provide: ENABLE_ALPHA_SELECTOR, useValue: false },
         { provide: DISABLE_SELECTED_COLOR_ICON, useValue: false },
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
+        { provide: SELECTED_COLOR_SVG_ICON, useValue: 'done' },
         { provide: EMPTY_COLOR, useValue: 'none'},
         { provide: USED_COLORS, useValue: []},
       ]

--- a/src/lib/color-picker/color-picker.ts
+++ b/src/lib/color-picker/color-picker.ts
@@ -18,9 +18,6 @@ export const DISABLE_SELECTED_COLOR_ICON = new InjectionToken<boolean>('disable-
 /** Enable alpha selector **/
 export const ENABLE_ALPHA_SELECTOR = new InjectionToken<boolean>('enable-alpha-selector');
 
-/** Hold the name of svg selected icon */
-export const SVG_SELECTED_ICON_NAME = 'mcc-svg-color-picker';
-
 /**
  *
  */


### PR DESCRIPTION
Leaving registration of the SVG for the selected color in MatIconRegistry to the project using the color-picker. This enables the use of icon sets. 

linked to https://github.com/tiaguinho/material-community-components/issues/134