### PR TITLE
feat(color-picker): Configurable color string format (HEX,RGB,HSL,HSV)

### DIFF
--- a/src/demo-app/app/app.component.html
+++ b/src/demo-app/app/app.component.html
@@ -53,7 +53,7 @@
         </a>
       </div>
       <div class="version">
-        Current Version: 7.0.0
+        Current Version: 7.2.0
       </div>
       <div class="github">
         <a href="https://github.com/tiaguinho/material-community-components">

--- a/src/demo-app/app/color-picker/color-picker.module.ts
+++ b/src/demo-app/app/color-picker/color-picker.module.ts
@@ -9,12 +9,12 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
-import { MccColorPickerModule } from '../../../lib/color-picker';
 import { ColorPickerComponent } from './color-picker.component';
 import { routes } from './color-picker.router';
 import { ColorPickerAlphaComponent } from './components/color-picker-alpha.component';
 import { ColorPickerApiComponent } from './components/color-picker-api.component';
 import { ColorPickerExamplesComponent } from './components/color-picker-examples.component';
+import { MccColorPickerModule } from '../../../lib/color-picker/public_api';
 
 
 

--- a/src/demo-app/app/color-picker/components/color-picker-alpha.component.html
+++ b/src/demo-app/app/color-picker/components/color-picker-alpha.component.html
@@ -45,17 +45,14 @@
   <mat-card-content>
     <mcc-color-picker [usedColorLabel]="'My Colors'" (selected)="selectedColor = $event">
 
-      <mcc-color-picker-collection [label]="'First Collection'" [colors]="colors">
-      </mcc-color-picker-collection>
-
     </mcc-color-picker>
   </mat-card-content>
 </mat-card>
 
-<!-- CONNECT COLOR PICKER WITH AN INPUT -->
+<!-- CONNECT COLOR PICKER WITH AN INPUT With RGB OUTPUT-->
 <mat-card>
   <mat-card-header>
-    <mat-card-title>Connect color picker with an input (with Alpha enabled)</mat-card-title>
+    <mat-card-title>Connect color picker with an input with RGB output (with Alpha enabled)</mat-card-title>
   </mat-card-header>
 
   <mat-card-content>

--- a/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
+++ b/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from '../../../../lib/color-picker';
+import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from '../../../../lib/color-picker/public_api';
 
 @Component({
   selector: 'app-color-picker-alpha',

--- a/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
+++ b/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from '../../../../lib/color-picker';
-import { COLOR_STRING_FORMAT } from '../../../../lib/color-picker/color-picker';
 
 @Component({
   selector: 'app-color-picker-alpha',
@@ -10,8 +9,7 @@ import { COLOR_STRING_FORMAT } from '../../../../lib/color-picker/color-picker';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     { provide: ENABLE_ALPHA_SELECTOR, useValue: true},
-    { provide: EMPTY_COLOR, useValue: ''},
-    { provide: COLOR_STRING_FORMAT, useValue: 'hsl'}
+    { provide: EMPTY_COLOR, useValue: ''}
   ]
 })
 export class ColorPickerAlphaComponent implements OnInit {

--- a/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
+++ b/src/demo-app/app/color-picker/components/color-picker-alpha.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from '../../../../lib/color-picker';
+import { COLOR_STRING_FORMAT } from '../../../../lib/color-picker/color-picker';
 
 @Component({
   selector: 'app-color-picker-alpha',
@@ -9,7 +10,8 @@ import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from '../../../../lib/color-picker
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     { provide: ENABLE_ALPHA_SELECTOR, useValue: true},
-    { provide: EMPTY_COLOR, useValue: ''}
+    { provide: EMPTY_COLOR, useValue: ''},
+    { provide: COLOR_STRING_FORMAT, useValue: 'hsl'}
   ]
 })
 export class ColorPickerAlphaComponent implements OnInit {

--- a/src/demo-app/app/color-picker/components/color-picker-examples.component.ts
+++ b/src/demo-app/app/color-picker/components/color-picker-examples.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MccColorPickerItem, MccColorPickerService } from '../../../../lib/color-picker';
+import { MccColorPickerItem, MccColorPickerService } from '../../../../lib/color-picker/public_api';
 
 @Component({
   selector: 'app-color-picker-examples',

--- a/src/demo-app/app/color-picker/components/color-picker-examples.component.ts
+++ b/src/demo-app/app/color-picker/components/color-picker-examples.component.ts
@@ -34,8 +34,12 @@ export class ColorPickerExamplesComponent implements OnInit {
   ];
 
   colors: string[] = [
-    '#FF6633',
-    '#FFB399',
+    '#000zzz',
+    'zzzzzz',
+    '#ff6633',
+    'ff6638',
+    'fFb399',
+    'rgb(140,140,140)',
     '#FF33FF',
     '#FFFF99',
     '#00B3E6',

--- a/src/demo-app/app/scrollspy/components/scrollspy-examples.component.ts
+++ b/src/demo-app/app/scrollspy/components/scrollspy-examples.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectorRef, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
-import { MccScrollspyService, MccScrollspyItemDirective } from '../../../../lib/scrollspy';
 import { Subscription } from 'rxjs';
+import { MccScrollspyItemDirective, MccScrollspyService } from '../../../../lib/scrollspy/public_api';
 
 @Component({
   selector: 'app-scrollspy-examples',

--- a/src/demo-app/app/scrollspy/scrollspy.module.ts
+++ b/src/demo-app/app/scrollspy/scrollspy.module.ts
@@ -6,10 +6,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
-import { MccScrollspyModule } from '../../../lib/scrollspy';
 import { ScrollspyExamplesComponent } from './components/scrollspy-examples.component';
 import { ScrollspyComponent } from './scrollspy.component';
 import { routes } from './scrollspy.router';
+import { MccScrollspyModule } from '../../../lib/scrollspy/public_api';
 
 
 

--- a/src/demo-app/app/speed-dial/speed-dial.module.ts
+++ b/src/demo-app/app/speed-dial/speed-dial.module.ts
@@ -9,11 +9,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
-import { MccSpeedDialModule } from '../../../lib/speed-dial';
 import { SpeedDialApiComponent } from './components/speed-dial-api.component';
 import { SpeedDialExamplesComponent } from './components/speed-dial-examples.component';
 import { SpeedDialComponent } from './speed-dial.component';
 import { routes } from './speed-dial.router';
+import { MccSpeedDialModule } from '../../../lib/speed-dial/public_api';
 
 @NgModule({
   imports: [

--- a/src/demo-app/app/timer-picker/timer-picker.module.ts
+++ b/src/demo-app/app/timer-picker/timer-picker.module.ts
@@ -8,11 +8,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
-import { MccTimerPickerModule } from '../../../lib/timer-picker';
 import { TimerPickerApiComponent } from './components/timer-picker-api.component';
 import { TimerPickerExamplesComponent } from './components/timer-picker-examples.component';
 import { TimerPickerComponent } from './timer-picker.component';
 import { routes } from './timer-picker.router';
+import { MccTimerPickerModule } from '../../../lib/timer-picker/public_api';
 
 
 

--- a/src/lib/color-picker/color-picker-collection.component.spec.ts
+++ b/src/lib/color-picker/color-picker-collection.component.spec.ts
@@ -12,7 +12,7 @@ import {
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
-} from './color-picker';
+} from './color-picker.types';
 import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
 

--- a/src/lib/color-picker/color-picker-collection.component.spec.ts
+++ b/src/lib/color-picker/color-picker-collection.component.spec.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerService } from './color-picker.service';
 import {
+  COLOR_STRING_FORMAT,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
   ENABLE_ALPHA_SELECTOR,
@@ -32,7 +33,8 @@ describe('MccColorPickerCollectionComponent', () => {
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
         { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none' },
-        { provide: USED_COLORS, useValue: [] }
+        { provide: USED_COLORS, useValue: [] },
+        { provide: COLOR_STRING_FORMAT, useValue: 'hex'}
       ]
     });
 

--- a/src/lib/color-picker/color-picker-collection.component.spec.ts
+++ b/src/lib/color-picker/color-picker-collection.component.spec.ts
@@ -3,7 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
-import { MccColorPickerOptionDirective } from './color-picker.directives';
 import { MccColorPickerService } from './color-picker.service';
 import {
   DISABLE_SELECTED_COLOR_ICON,
@@ -13,6 +12,7 @@ import {
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
 } from './color-picker';
+import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 describe('MccColorPickerCollectionComponent', () => {
   let comp: MccColorPickerCollectionComponent;

--- a/src/lib/color-picker/color-picker-collection.component.spec.ts
+++ b/src/lib/color-picker/color-picker-collection.component.spec.ts
@@ -14,6 +14,7 @@ import {
   USED_COLORS
 } from './color-picker';
 import { MccColorPickerOptionDirective } from './color-picker-option.directive';
+import { MccColorPickerCollectionService } from './color-picker-collection.service';
 
 describe('MccColorPickerCollectionComponent', () => {
   let comp: MccColorPickerCollectionComponent;
@@ -27,6 +28,7 @@ describe('MccColorPickerCollectionComponent', () => {
       declarations: [MccColorPickerCollectionComponent, MccColorPickerOptionDirective],
       providers: [
         MccColorPickerService,
+        MccColorPickerCollectionService,
         { provide: ComponentFixtureAutoDetect, useValue: true },
         { provide: ENABLE_ALPHA_SELECTOR, useValue: false },
         { provide: DISABLE_SELECTED_COLOR_ICON, useValue: false },
@@ -34,7 +36,7 @@ describe('MccColorPickerCollectionComponent', () => {
         { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none' },
         { provide: USED_COLORS, useValue: [] },
-        { provide: COLOR_STRING_FORMAT, useValue: 'hex'}
+        { provide: COLOR_STRING_FORMAT, useValue: 'hex'},
       ]
     });
 

--- a/src/lib/color-picker/color-picker-collection.component.ts
+++ b/src/lib/color-picker/color-picker-collection.component.ts
@@ -14,15 +14,14 @@ import {
   ColorFormat,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
-  formatColor,
   MccColorPickerItem,
   MccColorPickerOption,
-  parseColorString,
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON
-} from './color-picker';
+} from './color-picker.types';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
+import { formatColor, parseColorString } from './color-picker.utils';
 
 @Component({
   selector: 'mcc-color-picker-collection',

--- a/src/lib/color-picker/color-picker-collection.component.ts
+++ b/src/lib/color-picker/color-picker-collection.component.ts
@@ -22,7 +22,7 @@ import {
   SELECTED_COLOR_SVG_ICON
 } from './color-picker';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { MccColorPickerService } from './color-picker.service';
+import { MccColorPickerCollectionService } from './color-picker-collection.service';
 
 @Component({
   selector: 'mcc-color-picker-collection',
@@ -104,8 +104,9 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
   @Output() changeColor: EventEmitter<string> = new EventEmitter<string>();
 
   /**
-   * Return selected color
+   * Current selected color
    */
+  @Input()
   get selectedColor(): string {
     return this._selectedColor;
   }
@@ -132,7 +133,7 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private colorPickerService: MccColorPickerService,
+    private colorPickerCollectionService: MccColorPickerCollectionService,
     @Inject(EMPTY_COLOR) public emptyColor: string,
     @Inject(SELECTED_COLOR_ICON) private selectedColorIcon: string,
     @Inject(SELECTED_COLOR_SVG_ICON) public selectedColorSvgIcon: string,
@@ -143,7 +144,7 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
 
   ngOnInit() {
     // get current selected color
-    this.colorPickerService.getSelectedColor().subscribe(color => {
+    this.colorPickerCollectionService.getSelectedColor().subscribe(color => {
       this._selectedColor = color;
       this.changeDetectorRef.detectChanges();
     });
@@ -190,7 +191,7 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
   setColor(option: MccColorPickerOption) {
     const color = typeof option === 'string' ? option : option.value;
 
-    this.colorPickerService.changeSelectedColor(color);
+    this.colorPickerCollectionService.changeSelectedColor(color);
     this.changeColor.emit(color);
   }
 

--- a/src/lib/color-picker/color-picker-collection.component.ts
+++ b/src/lib/color-picker/color-picker-collection.component.ts
@@ -10,8 +10,12 @@ import {
   Output,
 } from '@angular/core';
 import {
+  COLOR_STRING_FORMAT,
+  ColorFormat,
   DISABLE_SELECTED_COLOR_ICON,
-  EMPTY_COLOR, MccColorPickerItem,
+  EMPTY_COLOR,
+  formatColor,
+  MccColorPickerItem,
   MccColorPickerOption,
   parseColorString,
   SELECTED_COLOR_ICON,
@@ -62,7 +66,24 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
   }
 
   set colors(values: MccColorPickerOption[]) {
-    this._colors = values;
+    // TODO: strange bug wher color are not mapped
+    // map color string from user to string based on configured format
+    const colors: MccColorPickerOption[] = [];
+    values.forEach(value => {
+      if (typeof value === 'string') {
+        const clr = parseColorString(value);
+        if (clr) {
+          colors.push(formatColor(clr, this.colorStringFormat));
+        }
+      } else {
+        const clr = parseColorString(value.value);
+        if (clr) {
+          colors.push({value: formatColor(clr, this.colorStringFormat), text: value.text});
+        }
+      }
+    });
+
+    this._colors = colors;
   }
 
   private _colors: MccColorPickerOption[];
@@ -115,7 +136,8 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
     @Inject(EMPTY_COLOR) public emptyColor: string,
     @Inject(SELECTED_COLOR_ICON) private selectedColorIcon: string,
     @Inject(SELECTED_COLOR_SVG_ICON) public selectedColorSvgIcon: string,
-    @Inject(DISABLE_SELECTED_COLOR_ICON) public disableSelectedIcon: boolean
+    @Inject(DISABLE_SELECTED_COLOR_ICON) public disableSelectedIcon: boolean,
+    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
   ) {
   }
 

--- a/src/lib/color-picker/color-picker-collection.component.ts
+++ b/src/lib/color-picker/color-picker-collection.component.ts
@@ -137,7 +137,7 @@ export class MccColorPickerCollectionComponent implements OnInit, AfterContentCh
     @Inject(SELECTED_COLOR_ICON) private selectedColorIcon: string,
     @Inject(SELECTED_COLOR_SVG_ICON) public selectedColorSvgIcon: string,
     @Inject(DISABLE_SELECTED_COLOR_ICON) public disableSelectedIcon: boolean,
-    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
+    @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
   ) {
   }
 

--- a/src/lib/color-picker/color-picker-collection.service.ts
+++ b/src/lib/color-picker/color-picker-collection.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { COLOR_STRING_FORMAT, ColorFormat, formatColor, parseColorString } from './color-picker';
+import { COLOR_STRING_FORMAT, ColorFormat} from './color-picker.types';
+import { formatColor, parseColorString } from './color-picker.utils';
 
 
 @Injectable()

--- a/src/lib/color-picker/color-picker-collection.service.ts
+++ b/src/lib/color-picker/color-picker-collection.service.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { COLOR_STRING_FORMAT, ColorFormat, formatColor, parseColorString } from './color-picker';
+
+
+@Injectable()
+export class MccColorPickerCollectionService {
+
+  /**
+   * Hold current selected color
+   */
+  private _selectedColor: BehaviorSubject<string> = new BehaviorSubject<string>('');
+
+
+  constructor(@Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat) {
+  }
+
+  /**
+   * Change internal selected color
+   */
+  changeSelectedColor(colorString: string) {
+    const color = parseColorString(colorString);
+
+    if (!colorString || !color) {
+      return;
+    }
+
+    const clrString = formatColor(color, this.colorStringFormat);
+    this._selectedColor.next(clrString);
+  }
+
+  /**
+   * Return internal selected color
+   */
+  getSelectedColor(): Observable<string> {
+    return this._selectedColor.asObservable();
+  }
+}

--- a/src/lib/color-picker/color-picker-option.directive.ts
+++ b/src/lib/color-picker/color-picker-option.directive.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Directive, ElementRef, Inject, Input, Renderer2 } from '@angular/core';
-import { EMPTY_COLOR, MccColorPickerOption, parseColorString } from './color-picker';
+import { EMPTY_COLOR, MccColorPickerOption} from './color-picker.types';
+import { parseColorString } from './color-picker.utils';
 
 /**
  * This directive change the background of the button

--- a/src/lib/color-picker/color-picker-option.directive.ts
+++ b/src/lib/color-picker/color-picker-option.directive.ts
@@ -1,0 +1,52 @@
+import { AfterViewInit, Directive, ElementRef, Inject, Input, Renderer2 } from '@angular/core';
+import { EMPTY_COLOR, MccColorPickerOption, parseColorString } from './color-picker';
+
+/**
+ * This directive change the background of the button
+ */
+@Directive({
+  selector: '[mccColorPickerOption], [mcc-color-picker-option]',
+  exportAs: 'mccColorPickerOption',
+})
+export class MccColorPickerOptionDirective implements AfterViewInit {
+  /**
+   * Receive the color
+   */
+  @Input('mccColorPickerOption')
+  get color(): MccColorPickerOption {
+    return this._color;
+  }
+  set color(value: MccColorPickerOption) {
+    this._color = value;
+  }
+  private _color: MccColorPickerOption;
+
+  constructor(
+    private elementRef: ElementRef,
+    private render: Renderer2,
+    @Inject(EMPTY_COLOR) private emptyColor: string
+  ) {
+    this._color = emptyColor;
+  }
+
+  ngAfterViewInit() {
+    if (this.color) {
+      let color: string;
+      if (typeof this.color === 'string') {
+        color = this.color;
+      } else {
+        color = this.color.value;
+        this.render.setAttribute(this.elementRef.nativeElement, 'aria-label', this.color.text);
+      }
+
+      if (parseColorString(color)) {
+        // apply the color
+        this.render.setStyle(
+          this.elementRef.nativeElement,
+          'backgroundColor',
+          color
+        );
+      }
+    }
+  }
+}

--- a/src/lib/color-picker/color-picker-origin.directive.ts
+++ b/src/lib/color-picker/color-picker-origin.directive.ts
@@ -37,7 +37,7 @@ export class MccColorPickerOriginDirective implements ControlValueAccessor {
     private renderer: Renderer2,
     @Inject(EMPTY_COLOR) private emptyColor: string,
     @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
-    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
+    @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
   ) {
     // listen changes onkeyup and update color picker
     renderer.listen(elementRef.nativeElement, 'keyup', (event: KeyboardEvent) => {
@@ -133,7 +133,7 @@ export class MccConnectedColorPickerDirective implements AfterViewInit, OnDestro
     private colorPicker: MccColorPickerComponent,
     public changeDetectorRef: ChangeDetectorRef,
     @Inject(EMPTY_COLOR) private emptyColor: string,
-    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
+    @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
   ) {
   }
 

--- a/src/lib/color-picker/color-picker-origin.directive.ts
+++ b/src/lib/color-picker/color-picker-origin.directive.ts
@@ -2,7 +2,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Directive,
-  ElementRef,
+  ElementRef, EventEmitter,
   forwardRef,
   Inject,
   Input,
@@ -14,56 +14,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MccColorPickerComponent } from './color-picker.component';
 import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR, MccColorPickerOption, parseColorString, toHex, toRgba } from './color-picker';
 import { BehaviorSubject, Subscription } from 'rxjs';
-
-/**
- * This directive change the background of the button
- */
-@Directive({
-  selector: '[mccColorPickerOption], [mcc-color-picker-option]',
-  exportAs: 'mccColorPickerOption',
-})
-export class MccColorPickerOptionDirective implements AfterViewInit {
-  /**
-   * Receive the color
-   */
-  @Input('mccColorPickerOption')
-  get color(): MccColorPickerOption {
-    return this._color;
-  }
-  set color(value: MccColorPickerOption) {
-    this._color = value;
-  }
-  private _color: MccColorPickerOption;
-
-  constructor(
-    private elementRef: ElementRef,
-    private render: Renderer2,
-    @Inject(EMPTY_COLOR) private emptyColor: string
-  ) {
-    this._color = emptyColor;
-  }
-
-  ngAfterViewInit() {
-    if (this.color) {
-      let color: string;
-      if (typeof this.color === 'string') {
-        color = this.color;
-      } else {
-        color = this.color.value;
-        this.render.setAttribute(this.elementRef.nativeElement, 'aria-label', this.color.text);
-      }
-
-      if (parseColorString(color)) {
-        // apply the color
-        this.render.setStyle(
-          this.elementRef.nativeElement,
-          'backgroundColor',
-          color
-        );
-      }
-    }
-  }
-}
 
 /**
  * Directive applied to an element to make it usable as an origin for an ColorPicker.
@@ -83,7 +33,7 @@ export class MccColorPickerOriginDirective implements ControlValueAccessor {
   /**
    * Emit changes from the origin
    */
-  @Output() change: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  @Output() change: EventEmitter<string> = new EventEmitter<string>();
 
   /**
    * Propagate changes to angular

--- a/src/lib/color-picker/color-picker-origin.directive.ts
+++ b/src/lib/color-picker/color-picker-origin.directive.ts
@@ -1,8 +1,9 @@
 import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, forwardRef, Inject, Input, OnDestroy, Renderer2, } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MccColorPickerComponent } from './color-picker.component';
-import { COLOR_STRING_FORMAT, ColorFormat, EMPTY_COLOR, ENABLE_ALPHA_SELECTOR, formatColor, parseColorString } from './color-picker';
+import { COLOR_STRING_FORMAT, ColorFormat, EMPTY_COLOR, ENABLE_ALPHA_SELECTOR} from './color-picker.types';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import { formatColor, parseColorString } from './color-picker.utils';
 
 /**
  * Directive applied to an element to make it usable as an origin for an ColorPicker.

--- a/src/lib/color-picker/color-picker-selector.component.html
+++ b/src/lib/color-picker/color-picker-selector.component.html
@@ -17,7 +17,7 @@
 
 </div>
 
-<div class="mcc-color-picker-selector-preview" [style.backgroundColor]="tmpSelectedColor$ | async">
+<div class="mcc-color-picker-selector-preview" [style.backgroundColor]="tmpSelectedColorAsRgba$ | async">
   <ng-container *ngIf="!hideHexForms && !noColor">
     <form [formGroup]="hexForm">
       <mat-form-field class="hex-input" floatLabel="always" [ngClass]="textClass">

--- a/src/lib/color-picker/color-picker-selector.component.html
+++ b/src/lib/color-picker/color-picker-selector.component.html
@@ -27,7 +27,7 @@
 
     <form [formGroup]="rgbaForm">
       <mat-form-field class="rgb-input" floatLabel="always" [ngClass]="textClass">
-        <input matInput type="number" placeholder="RGBA" formControlName="R"/>
+        <input matInput type="number" [placeholder]="showAlphaSelector ? 'RGBA' : 'RGB'" formControlName="R"/>
       </mat-form-field>
       <mat-form-field class="rgb-input" floatLabel="always" [ngClass]="textClass">
         <input matInput type="number" formControlName="G"/>

--- a/src/lib/color-picker/color-picker-selector.component.html
+++ b/src/lib/color-picker/color-picker-selector.component.html
@@ -1,17 +1,17 @@
 <div class="mcc-color-picker-selector" [ngStyle]="{ 'height.px': selectorHeight }">
   <div #block class="mcc-picker-selector" [style.height.px]="selectorHeight" [style.width.px]="selectorWidth"></div>
   <canvas #blockCanvas [height]="selectorHeight" [width]="selectorWidth" id="picker"></canvas>
-  <div #blockPointer class="mcc-picker-position" style="top: 0px;left: 220px;"></div>
+  <div #blockPointer class="mcc-picker-position" style="top: 0; left: 0;"></div>
 
   <div #hueContainer class="mcc-colors-position" [style.height.px]="selectorHeight"
        [ngClass]="{'alpha-enabled': showAlphaSelector}"
-       style="background-position-y: 0px;">
+       style="background-position-y: 0;">
     <canvas #hueSelector [height]="stripHeight" [width]="stripWidth" id="colors"></canvas>
   </div>
 
 
   <div *ngIf="showAlphaSelector" #alphaContainer class="mcc-alpha-position" [style.height.px]="selectorHeight"
-       style="background-position-y: 0px;">
+       style="background-position-y: 0;">
     <canvas #alpha [height]="stripHeight" [width]="stripWidth" id="alpha"></canvas>
   </div>
 

--- a/src/lib/color-picker/color-picker-selector.component.scss
+++ b/src/lib/color-picker/color-picker-selector.component.scss
@@ -102,7 +102,7 @@ canvas {
   }
 
   .hex-input {
-    width: 70px;
+    width: 86px;
     margin-right: 20px;
 
     input {

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -18,8 +18,8 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR, parseColorString, toHex, toRgba } from './color-picker';
 import { tinycolor } from '@thebespokepixel/es-tinycolor';
-import type { Instance } from 'tinycolor2';
-import { map } from 'rxjs/operators';
+import { Instance } from 'tinycolor2';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import { MccColorPickerService } from './color-picker.service';
 
 
@@ -221,8 +221,8 @@ export class MccColorPickerSelectorComponent
 
   private _stripWidth: number = 20;
 
-  get tmpSelectedColor$(): Observable<string> {
-    return this._tmpSelectedColor.asObservable().pipe(map(toRgba));
+  get tmpSelectedColorAsRgba$(): Observable<string> {
+    return this._tmpSelectedColor.asObservable().pipe(map(toRgba), distinctUntilChanged());
   }
 
   constructor(

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -360,6 +360,7 @@ export class MccColorPickerSelectorComponent
     }));
 
     this._mouseDownListeners.push(this.renderer.listen(this._block.nativeElement, 'mousedown', (e: MouseEvent) => {
+      e.preventDefault();
       this._isPressed = true;
       this._selectionTargetPosition = this._block.nativeElement.getBoundingClientRect();
       this._listenToMouseForBlock();
@@ -383,6 +384,7 @@ export class MccColorPickerSelectorComponent
 
     this._mouseDownListeners.push(
       this.renderer.listen(this._hueSelector.nativeElement, 'mousedown', (e: MouseEvent) => {
+        e.preventDefault();
         this._isPressed = true;
         this._selectionTargetPosition = this._hueSelector.nativeElement.getBoundingClientRect();
         this._listenToMouseForHue();
@@ -406,6 +408,7 @@ export class MccColorPickerSelectorComponent
 
       this._mouseDownListeners.push(
         this.renderer.listen(this._alpha.nativeElement, 'mousedown', (e: MouseEvent) => {
+          e.preventDefault();
           this._isPressed = true;
           this._selectionTargetPosition = this._alpha.nativeElement.getBoundingClientRect();
           this._listenToMouseForAlpha();
@@ -540,6 +543,7 @@ export class MccColorPickerSelectorComponent
 
     this._temporaryMouseListeners.push(
       this.renderer.listen(document, 'mouseup', (e: MouseEvent) => {
+        e.preventDefault();
         this._isPressed = false;
         this._temporaryMouseListeners.forEach(listener => listener());
       })

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -16,7 +16,16 @@ import {
 } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR, parseColorString, toHex, toRgba } from './color-picker';
+import {
+  COLOR_STRING_FORMAT,
+  ColorFormat,
+  EMPTY_COLOR,
+  ENABLE_ALPHA_SELECTOR,
+  formatColor,
+  parseColorString,
+  toHex,
+  toRgb
+} from './color-picker';
 import { tinycolor } from '@thebespokepixel/es-tinycolor';
 import { Instance } from 'tinycolor2';
 import { distinctUntilChanged, map } from 'rxjs/operators';
@@ -222,7 +231,7 @@ export class MccColorPickerSelectorComponent
   private _stripWidth: number = 20;
 
   get tmpSelectedColorAsRgba$(): Observable<string> {
-    return this._tmpSelectedColor.asObservable().pipe(map(toRgba), distinctUntilChanged());
+    return this._tmpSelectedColor.asObservable().pipe(map(toRgb), distinctUntilChanged());
   }
 
   constructor(
@@ -230,7 +239,8 @@ export class MccColorPickerSelectorComponent
     private renderer: Renderer2,
     private colorPickerService: MccColorPickerService,
     @Inject(EMPTY_COLOR) private emptyColor: string,
-    @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean
+    @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
+    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
   ) {
   }
 
@@ -247,12 +257,8 @@ export class MccColorPickerSelectorComponent
       if (this.noColor) {
         this.changeSelectedColor.emit(this.emptyColor);
         this.colorPickerService.changeSelectedColor(this.emptyColor);
-      } else if (this.showAlphaSelector) {
-        const clr = toRgba(color);
-        this.changeSelectedColor.emit(clr);
-        this.colorPickerService.changeSelectedColor(clr);
       } else {
-        const clr = toHex(color);
+        const clr = formatColor(color, this.colorStringFormat);
         this.changeSelectedColor.emit(clr);
         this.colorPickerService.changeSelectedColor(clr);
       }

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -579,13 +579,15 @@ export class MccColorPickerSelectorComponent
     this._hueSelectorContext.rect(0, 0, this._hueSelector.nativeElement.width, this._hueSelector.nativeElement.height);
 
     const grd1 = this._hueSelectorContext.createLinearGradient(0, 0, 0, this._bc.nativeElement.height);
-    grd1.addColorStop(0, 'rgba(255, 0, 0, 1)');
-    grd1.addColorStop(0.17, 'rgba(255, 255, 0, 1)');
-    grd1.addColorStop(0.34, 'rgba(0, 255, 0, 1)');
-    grd1.addColorStop(0.51, 'rgba(0, 255, 255, 1)');
-    grd1.addColorStop(0.68, 'rgba(0, 0, 255, 1)');
-    grd1.addColorStop(0.85, 'rgba(255, 0, 255, 1)');
-    grd1.addColorStop(1, 'rgba(255, 0, 0, 1)');
+    grd1.addColorStop(0, 'hsl(0, 100%, 50%)');
+    grd1.addColorStop(0.125, 'hsl(45, 100%, 50%)');
+    grd1.addColorStop(0.25, 'hsl(90, 100%, 50%)');
+    grd1.addColorStop(0.375, 'hsl(135, 100%, 50%)');
+    grd1.addColorStop(0.5, 'hsl(180, 100%, 50%)');
+    grd1.addColorStop(0.625, 'hsl(225, 100%, 50%)');
+    grd1.addColorStop(0.75, 'hsl(270, 100%, 50%)');
+    grd1.addColorStop(0.875, 'hsl(315, 100%, 50%)');
+    grd1.addColorStop(1, 'hsl(360, 100%, 50%)');
     this._hueSelectorContext.fillStyle = grd1;
     this._hueSelectorContext.fill();
   }

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -21,15 +21,12 @@ import {
   COLOR_STRING_FORMAT,
   ColorFormat,
   EMPTY_COLOR,
-  ENABLE_ALPHA_SELECTOR,
-  formatColor,
-  parseColorString,
-  toHex,
-  toRgb
-} from './color-picker';
+  ENABLE_ALPHA_SELECTOR
+} from './color-picker.types';
 import { TinyColor } from '@thebespokepixel/es-tinycolor';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
+import { formatColor, parseColorString, toHex, toRgb } from './color-picker.utils';
 
 
 interface Coordinates {

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -29,7 +29,7 @@ import {
 import { tinycolor } from '@thebespokepixel/es-tinycolor';
 import { Instance } from 'tinycolor2';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-import { MccColorPickerService } from './color-picker.service';
+import { MccColorPickerCollectionService } from './color-picker-collection.service';
 
 
 interface Coordinates {
@@ -237,7 +237,7 @@ export class MccColorPickerSelectorComponent
   constructor(
     private formBuilder: FormBuilder,
     private renderer: Renderer2,
-    private colorPickerService: MccColorPickerService,
+    private colorPickerCollectionService: MccColorPickerCollectionService,
     @Inject(EMPTY_COLOR) private emptyColor: string,
     @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
     @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
@@ -256,11 +256,11 @@ export class MccColorPickerSelectorComponent
       // right now using hex for non alpha and rgba for alpha colors
       if (this.noColor) {
         this.changeSelectedColor.emit(this.emptyColor);
-        this.colorPickerService.changeSelectedColor(this.emptyColor);
+        this.colorPickerCollectionService.changeSelectedColor(this.emptyColor);
       } else {
         const clr = formatColor(color, this.colorStringFormat);
         this.changeSelectedColor.emit(clr);
-        this.colorPickerService.changeSelectedColor(clr);
+        this.colorPickerCollectionService.changeSelectedColor(clr);
       }
     });
 

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -776,8 +776,7 @@ export class MccColorPickerSelectorComponent
    */
   private setXYSelector(offsets: Coordinates) {
     if (this._bp) {
-      this.renderer.setStyle(this._bp.nativeElement, 'top', `${offsets.y - 5}px`);
-      this.renderer.setStyle(this._bp.nativeElement, 'left', `${offsets.x - 6}px`);
+      this.renderer.setStyle(this._bp.nativeElement, 'transform', `translate(${offsets.x - 6}px, ${offsets.y - 6}px)`);
       this._latestBlockCoordinates = offsets;
     }
   }

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -240,7 +240,7 @@ export class MccColorPickerSelectorComponent
     private colorPickerService: MccColorPickerService,
     @Inject(EMPTY_COLOR) private emptyColor: string,
     @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
-    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
+    @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
   ) {
   }
 

--- a/src/lib/color-picker/color-picker-selector.component.ts
+++ b/src/lib/color-picker/color-picker-selector.component.ts
@@ -17,6 +17,7 @@ import {
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import {
+  Color,
   COLOR_STRING_FORMAT,
   ColorFormat,
   EMPTY_COLOR,
@@ -26,8 +27,7 @@ import {
   toHex,
   toRgb
 } from './color-picker';
-import { tinycolor } from '@thebespokepixel/es-tinycolor';
-import { Instance } from 'tinycolor2';
+import { TinyColor } from '@thebespokepixel/es-tinycolor';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
 
@@ -37,7 +37,7 @@ interface Coordinates {
   y: number;
 }
 
-const INITIAL_COLOR: Instance = tinycolor('white');
+const INITIAL_COLOR: Color = new TinyColor('white');
 
 @Component({
   selector: 'mcc-color-picker-selector',
@@ -123,7 +123,7 @@ export class MccColorPickerSelectorComponent
       // use "EMPTY_COLOR" as real color if it can be parsed as such
       this._selectedColor = parseColorString(this.emptyColor) || INITIAL_COLOR;
     } else {
-      const color: Instance = tinycolor(value);
+      const color: Color = new TinyColor(value);
       if (color.isValid()) {
         this._selectedColor = color;
         this.noColor = false;
@@ -131,7 +131,7 @@ export class MccColorPickerSelectorComponent
     }
   }
 
-  private _selectedColor: Instance = INITIAL_COLOR;
+  private _selectedColor: Color = INITIAL_COLOR;
 
   /**
    * Hide the hexadecimal color forms.
@@ -156,7 +156,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Subject of the current selected color by the user
    */
-  private _tmpSelectedColor: BehaviorSubject<Instance> = new BehaviorSubject<Instance>(this._selectedColor);
+  private _tmpSelectedColor: BehaviorSubject<Color> = new BehaviorSubject<Color>(this._selectedColor);
 
   /**
    * Subscription of the tmpSelectedColor Observable
@@ -605,7 +605,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Generate alpha selector gradient based on the RGB color
    */
-  private _drawAlphaSelector(color: Instance) {
+  private _drawAlphaSelector(color: Color) {
     const background = new Image();
     background.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAIAAAD9iXMrAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAITcAACE3ATNYn3oAAACJSURBVChTjZDLDgQREEX9/6fRdvgAJMbSArvpud2ofibmLCqVOHUpbH3gnBNCLAP0xpjD++6gmXiEtfbdazHE2ZNS/psHtNZzj3O+eXg14b1H/VwJIaAyjJ7BdIyxJw9KKayn73u1ZuIRcw+R+Iinl3O+34uKV/fzweZhZ6CUahXAq7XiLiKl9AP878ZgrHOa/QAAAABJRU5ErkJggg==';
     background.onload = () => {
@@ -629,7 +629,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Generate color selector block based on the RGB color
    */
-  private _drawBlockSelector(hueColor: Instance) {
+  private _drawBlockSelector(hueColor: Color) {
     this._blockContext.fillStyle = `hsl(${hueColor.toHsl().h}, 100%, 50%)`;
     this._blockContext.fillRect(0, 0, this._bc.nativeElement.width, this._bc.nativeElement.height);
 
@@ -654,7 +654,7 @@ export class MccColorPickerSelectorComponent
     this._hexValuesSub = this.hexForm.valueChanges
       .subscribe(value => {
         if (this.hexForm.valid) {
-          const color: Instance = tinycolor(value.hexCode);
+          const color: Color = new TinyColor(value.hexCode);
           this._updateRGBAForm(color);
           this._drawBlockSelector(color);
           if (this.showAlphaSelector) {
@@ -667,7 +667,7 @@ export class MccColorPickerSelectorComponent
 
     this._rgbValuesSub = this.rgbaForm.valueChanges.subscribe(rgba => {
       if (this.rgbaForm.valid) {
-        const color: Instance = tinycolor({r: rgba.R, g: rgba.G, b: rgba.B, a: rgba.A});
+        const color: Color = new TinyColor({r: rgba.R, g: rgba.G, b: rgba.B, a: rgba.A});
         this._updateHexForm(color);
         this._drawBlockSelector(color);
         if (this.showAlphaSelector) {
@@ -682,7 +682,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Update RGBA form
    */
-  private _updateRGBAForm(color: Instance) {
+  private _updateRGBAForm(color: Color) {
     if (!this.rgbaForm) {
       return;
     }
@@ -693,7 +693,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Update hex form
    */
-  private _updateHexForm(color: Instance) {
+  private _updateHexForm(color: Color) {
     if (!this.hexForm) {
       return;
     }
@@ -711,7 +711,7 @@ export class MccColorPickerSelectorComponent
     if (y <= this.stripHeight) {
       this.setHueSelector(y);
       const data = this._hueSelectorContext.getImageData(this.stripWidth / 2, y, 1, 1).data;
-      const color: Instance = tinycolor({r: data[0], g: data[1], b: data[2]});
+      const color: Color = new TinyColor({r: data[0], g: data[1], b: data[2]});
       this._drawBlockSelector(color);
       this.changeColor();
     }
@@ -743,7 +743,7 @@ export class MccColorPickerSelectorComponent
       this.setXYSelector(os);
       // fixing getting values at border
       const data: Uint8ClampedArray = this._blockContext.getImageData(os.x ? os.x - 1 : os.x, os.y ? os.y - 1 : os.y, 1, 1).data;
-      const color: Instance = tinycolor({r: data[0], g: data[1], b: data[2], a: this._selectedColor.getAlpha()});
+      const color: Color = new TinyColor({r: data[0], g: data[1], b: data[2], a: this._selectedColor.getAlpha()});
       this._updateRGBAForm(color);
       this._updateHexForm(color);
       if (this.showAlphaSelector) {
@@ -758,7 +758,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Set all selectors positions based on a color
    */
-  private setSelectorPositions(color: Instance) {
+  private setSelectorPositions(color: Color) {
     const offset = this.getHueOffsets(color);
     this.setHueSelector(offset);
 
@@ -804,7 +804,7 @@ export class MccColorPickerSelectorComponent
   /**
    * Get the X and Y coordinates for the block selector relative to it's size
    */
-  private getXYOffsets(color: Instance): Coordinates {
+  private getXYOffsets(color: Color): Coordinates {
     const hsv = color.toHsv();
 
     const x = this._selectorWidth * hsv.s;
@@ -815,14 +815,14 @@ export class MccColorPickerSelectorComponent
   /**
    * Get the Y coordinate for the hue selector relative to it's height
    */
-  private getHueOffsets(color: Instance): number {
+  private getHueOffsets(color: Color): number {
     return this.stripHeight / 360 * color.toHsl().h;
   }
 
   /**
    * Get the Y coordinate for the alpha selector relative to it's height
    */
-  private getAlphaOffset(color: Instance): number {
+  private getAlphaOffset(color: Color): number {
     return this.stripHeight - this.stripHeight * color.getAlpha();
   }
 }

--- a/src/lib/color-picker/color-picker.component.spec.ts
+++ b/src/lib/color-picker/color-picker.component.spec.ts
@@ -14,6 +14,7 @@ import { MccColorPickerCollectionComponent } from './color-picker-collection.com
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
 import { MccColorPickerService } from './color-picker.service';
 import {
+  COLOR_STRING_FORMAT,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
   ENABLE_ALPHA_SELECTOR,
@@ -71,6 +72,7 @@ describe('MccColorPickerComponent', () => {
         { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none' },
         { provide: USED_COLORS, useValue: [] },
+        { provide: COLOR_STRING_FORMAT, useValue: 'hex' },
         { provide: ComponentFixtureAutoDetect, useValue: true },
       ]
     });

--- a/src/lib/color-picker/color-picker.component.spec.ts
+++ b/src/lib/color-picker/color-picker.component.spec.ts
@@ -12,7 +12,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MccColorPickerComponent } from './color-picker.component';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
-import { MccColorPickerOptionDirective } from './color-picker.directives';
 import { MccColorPickerService } from './color-picker.service';
 import {
   DISABLE_SELECTED_COLOR_ICON,
@@ -22,6 +21,7 @@ import {
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
 } from './color-picker';
+import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 describe('MccColorPickerComponent', () => {
   let comp: MccColorPickerComponent;

--- a/src/lib/color-picker/color-picker.component.spec.ts
+++ b/src/lib/color-picker/color-picker.component.spec.ts
@@ -21,7 +21,7 @@ import {
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
-} from './color-picker';
+} from './color-picker.types';
 import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 describe('MccColorPickerComponent', () => {

--- a/src/lib/color-picker/color-picker.component.ts
+++ b/src/lib/color-picker/color-picker.component.ts
@@ -16,7 +16,15 @@ import {
 } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { EMPTY_COLOR, ENABLE_ALPHA_SELECTOR, MccColorPickerUsedColorPosition, parseColorString, toHex, toRgba } from './color-picker';
+import {
+  COLOR_STRING_FORMAT,
+  ColorFormat,
+  EMPTY_COLOR,
+  ENABLE_ALPHA_SELECTOR,
+  formatColor,
+  MccColorPickerUsedColorPosition,
+  parseColorString
+} from './color-picker';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerService } from './color-picker.service';
 
@@ -171,11 +179,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     const color = parseColorString(value);
 
     if (color) {
-      if (this.showAlphaSelector) {
-        this._selectedColor = toRgba(color);
-      } else {
-        this._selectedColor = toHex(color);
-      }
+      this._selectedColor = formatColor(color, this.colorStringFormat);
     } else {
       this._selectedColor = this.emptyColor;
     }
@@ -272,7 +276,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
   /**
    * Event emitted when user change the selected color (without confirm)
    */
-  @Output()  readonly change = new EventEmitter<string>();
+  @Output() readonly change = new EventEmitter<string>();
 
   /**
    * Event emitted when selected color is confirm
@@ -282,12 +286,12 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
   /**
    * Event emitted when is clicked outside of the component
    */
-  @Output()  readonly clickOut = new EventEmitter<void>();
+  @Output() readonly clickOut = new EventEmitter<void>();
 
   /**
    * Event emitted when is clicked outside of the component
    */
-  @Output()  readonly canceled = new EventEmitter<void>();
+  @Output() readonly canceled = new EventEmitter<void>();
 
   /**
    * Return a Observable with the color the user is picking
@@ -317,7 +321,8 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     private changeDetectorRef: ChangeDetectorRef,
     private colorPickerService: MccColorPickerService,
     @Inject(EMPTY_COLOR) public emptyColor: string,
-    @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean
+    @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
+    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
   ) {
   }
 
@@ -368,7 +373,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
       const color = this._tmpSelectedColor.getValue();
       if (this._selectedColor !== color) {
         this._selectedColor = color;
-        this.selected.next(color);
+        this.selected.emit(color);
       } else {
         this.selected.emit(color);
       }
@@ -398,7 +403,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     } else {
       this.cancelSelection();
     }
-    this.clickOut.emit(null);
+    this.clickOut.emit();
   }
 
   /**
@@ -409,7 +414,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     if (color || color === this.emptyColor) {
       this._tmpSelectedColor.next(color);
       if (this._selectedColor !== color) {
-        this.change.next(color);
+        this.change.emit(color);
         if (this._hideButtons) {
           this._updateSelectedColor();
         }
@@ -422,7 +427,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
    */
   cancelSelection() {
     this._tmpSelectedColor.next(this._selectedColor);
-    this.canceled.emit(null);
+    this.canceled.emit();
     this.toggle();
   }
 

--- a/src/lib/color-picker/color-picker.component.ts
+++ b/src/lib/color-picker/color-picker.component.ts
@@ -27,6 +27,7 @@ import {
 } from './color-picker';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerService } from './color-picker.service';
+import { MccColorPickerCollectionService } from './color-picker-collection.service';
 
 @Component({
   selector: 'mcc-color-picker',
@@ -34,6 +35,7 @@ import { MccColorPickerService } from './color-picker.service';
   styleUrls: ['./color-picker.component.scss'],
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [MccColorPickerCollectionService]
 })
 export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDestroy {
   /**
@@ -320,6 +322,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     private elementRef: ElementRef,
     private changeDetectorRef: ChangeDetectorRef,
     private colorPickerService: MccColorPickerService,
+    private colorPickerCollectionService: MccColorPickerCollectionService,
     @Inject(EMPTY_COLOR) public emptyColor: string,
     @Inject(ENABLE_ALPHA_SELECTOR) public showAlphaSelector: boolean,
     @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
@@ -349,7 +352,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
     }
 
     // change selected color on service
-    this.selected.subscribe(color => this.colorPickerService.changeSelectedColor(color));
+    this.selected.subscribe(color => this.colorPickerCollectionService.changeSelectedColor(color));
   }
 
   /**
@@ -390,7 +393,7 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
         this.colorPickerService.addColor(this._selectedColor);
       }
 
-      this.colorPickerService.changeSelectedColor(this._selectedColor);
+      this.colorPickerCollectionService.changeSelectedColor(this._selectedColor);
     }
   }
 

--- a/src/lib/color-picker/color-picker.component.ts
+++ b/src/lib/color-picker/color-picker.component.ts
@@ -21,13 +21,12 @@ import {
   ColorFormat,
   EMPTY_COLOR,
   ENABLE_ALPHA_SELECTOR,
-  formatColor,
-  MccColorPickerUsedColorPosition,
-  parseColorString
-} from './color-picker';
+  MccColorPickerUsedColorPosition
+} from './color-picker.types';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerService } from './color-picker.service';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
+import { formatColor, parseColorString } from './color-picker.utils';
 
 @Component({
   selector: 'mcc-color-picker',

--- a/src/lib/color-picker/color-picker.component.ts
+++ b/src/lib/color-picker/color-picker.component.ts
@@ -272,22 +272,22 @@ export class MccColorPickerComponent implements AfterContentInit, OnInit, OnDest
   /**
    * Event emitted when user change the selected color (without confirm)
    */
-  @Output() change = new EventEmitter();
+  @Output()  readonly change = new EventEmitter<string>();
 
   /**
    * Event emitted when selected color is confirm
    */
-  @Output() selected = new EventEmitter();
+  @Output() readonly selected = new EventEmitter<string>();
 
   /**
    * Event emitted when is clicked outside of the component
    */
-  @Output() clickOut = new EventEmitter();
+  @Output()  readonly clickOut = new EventEmitter<void>();
 
   /**
    * Event emitted when is clicked outside of the component
    */
-  @Output() canceled = new EventEmitter();
+  @Output()  readonly canceled = new EventEmitter<void>();
 
   /**
    * Return a Observable with the color the user is picking

--- a/src/lib/color-picker/color-picker.directive.spec.ts
+++ b/src/lib/color-picker/color-picker.directive.spec.ts
@@ -22,7 +22,7 @@ import {
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
-} from './color-picker';
+} from './color-picker.types';
 import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 //

--- a/src/lib/color-picker/color-picker.directive.spec.ts
+++ b/src/lib/color-picker/color-picker.directive.spec.ts
@@ -15,6 +15,7 @@ import { MccColorPickerCollectionComponent } from './color-picker-collection.com
 import { MccColorPickerService } from './color-picker.service';
 import { MccColorPickerOriginDirective, MccConnectedColorPickerDirective } from './color-picker-origin.directive';
 import {
+  COLOR_STRING_FORMAT,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
   ENABLE_ALPHA_SELECTOR,
@@ -83,7 +84,8 @@ describe('MccConnectedColorPickerdirective', () => {
         { provide: SELECTED_COLOR_ICON, useValue: 'done' },
         { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
         { provide: EMPTY_COLOR, useValue: 'none'},
-        { provide: USED_COLORS, useValue: [] }
+        { provide: USED_COLORS, useValue: [] },
+        { provide: COLOR_STRING_FORMAT, useValue: 'hex' },
       ]
     });
 

--- a/src/lib/color-picker/color-picker.directive.spec.ts
+++ b/src/lib/color-picker/color-picker.directive.spec.ts
@@ -13,7 +13,7 @@ import { MccColorPickerComponent } from './color-picker.component';
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerService } from './color-picker.service';
-import { MccColorPickerOptionDirective, MccColorPickerOriginDirective, MccConnectedColorPickerDirective } from './color-picker.directives';
+import { MccColorPickerOriginDirective, MccConnectedColorPickerDirective } from './color-picker-origin.directive';
 import {
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
@@ -22,6 +22,7 @@ import {
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
 } from './color-picker';
+import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 //
 @Component({

--- a/src/lib/color-picker/color-picker.module.ts
+++ b/src/lib/color-picker/color-picker.module.ts
@@ -19,13 +19,12 @@ import {
   USED_COLORS
 } from './color-picker';
 
-import { MccColorPickerService } from './color-picker.service';
-
 import { MccColorPickerComponent } from './color-picker.component';
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
 import { MccColorPickerOriginDirective, MccConnectedColorPickerDirective, } from './color-picker-origin.directive';
 import { MccColorPickerOptionDirective } from './color-picker-option.directive';
+import { MccColorPickerService } from './color-picker.service';
 
 @NgModule({
   imports: [

--- a/src/lib/color-picker/color-picker.module.ts
+++ b/src/lib/color-picker/color-picker.module.ts
@@ -17,7 +17,7 @@ import {
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
-} from './color-picker';
+} from './color-picker.types';
 
 import { MccColorPickerComponent } from './color-picker.component';
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';

--- a/src/lib/color-picker/color-picker.module.ts
+++ b/src/lib/color-picker/color-picker.module.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 
 import {
+  COLOR_STRING_FORMAT,
   ColorPickerConfig,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
@@ -58,7 +59,8 @@ import { MccColorPickerOptionDirective } from './color-picker-option.directive';
     { provide: SELECTED_COLOR_ICON, useValue: 'done' },
     { provide: SELECTED_COLOR_SVG_ICON, useValue: null },
     { provide: EMPTY_COLOR, useValue: 'none' },
-    { provide: USED_COLORS, useValue: [] }
+    { provide: USED_COLORS, useValue: [] },
+    { provide: COLOR_STRING_FORMAT, useValue: 'hex' },
   ],
 })
 export class MccColorPickerModule {
@@ -74,7 +76,8 @@ export class MccColorPickerModule {
         { provide: SELECTED_COLOR_ICON, useValue: config.selected_icon || 'done' },
         { provide: SELECTED_COLOR_SVG_ICON, useValue: config.selected_svg_icon || null },
         { provide: EMPTY_COLOR, useValue: ('empty_color' in config ? config.empty_color : 'none') },
-        { provide: USED_COLORS, useValue: config.used_colors || [] }
+        { provide: USED_COLORS, useValue: config.used_colors || [] },
+        { provide: COLOR_STRING_FORMAT, useValue: config.color_string_format || 'hex' },
       ],
     };
   }

--- a/src/lib/color-picker/color-picker.module.ts
+++ b/src/lib/color-picker/color-picker.module.ts
@@ -23,7 +23,8 @@ import { MccColorPickerService } from './color-picker.service';
 import { MccColorPickerComponent } from './color-picker.component';
 import { MccColorPickerSelectorComponent } from './color-picker-selector.component';
 import { MccColorPickerCollectionComponent } from './color-picker-collection.component';
-import { MccColorPickerOptionDirective, MccColorPickerOriginDirective, MccConnectedColorPickerDirective, } from './color-picker.directives';
+import { MccColorPickerOriginDirective, MccConnectedColorPickerDirective, } from './color-picker-origin.directive';
+import { MccColorPickerOptionDirective } from './color-picker-option.directive';
 
 @NgModule({
   imports: [

--- a/src/lib/color-picker/color-picker.service.spec.ts
+++ b/src/lib/color-picker/color-picker.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { MccColorPickerService } from './color-picker.service';
 import {
+  COLOR_STRING_FORMAT,
   DISABLE_SELECTED_COLOR_ICON,
   EMPTY_COLOR,
   ENABLE_ALPHA_SELECTOR,
@@ -22,12 +23,14 @@ describe('MccColorPickerService', () => {
         { provide: SELECTED_COLOR_SVG_ICON, useValue: 'done' },
         { provide: EMPTY_COLOR, useValue: 'none'},
         { provide: USED_COLORS, useValue: []},
+        { provide: COLOR_STRING_FORMAT, useValue: 'hex'}
       ]
     });
 
     const emptyColorToken = TestBed.inject(EMPTY_COLOR);
     const usedColorsToken = TestBed.inject(USED_COLORS);
-    service = new MccColorPickerService(emptyColorToken, usedColorsToken);
+    const colorStringFormat = TestBed.inject(COLOR_STRING_FORMAT);
+    service = new MccColorPickerService(emptyColorToken, usedColorsToken, colorStringFormat);
   });
 
   it('should add color', (done: DoneFn) => {

--- a/src/lib/color-picker/color-picker.service.spec.ts
+++ b/src/lib/color-picker/color-picker.service.spec.ts
@@ -8,7 +8,7 @@ import {
   SELECTED_COLOR_ICON,
   SELECTED_COLOR_SVG_ICON,
   USED_COLORS
-} from './color-picker';
+} from './color-picker.types';
 
 describe('MccColorPickerService', () => {
   const color = '#FFFFFF';

--- a/src/lib/color-picker/color-picker.service.ts
+++ b/src/lib/color-picker/color-picker.service.ts
@@ -9,11 +9,6 @@ export class MccColorPickerService {
    */
   private _usedColors: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
 
-  /**
-   * Hold current selected color
-   */
-  private _selectedColor: BehaviorSubject<string> = new BehaviorSubject<string>('');
-
   constructor(
     @Inject(EMPTY_COLOR) private emptyColor: string,
     @Inject(USED_COLORS) private usedColors: string[],
@@ -62,26 +57,5 @@ export class MccColorPickerService {
    */
   resetUseColors(): void {
     this._usedColors.next([]);
-  }
-
-  /**
-   * Change internal selected color
-   */
-  changeSelectedColor(colorString: string) {
-    const color = parseColorString(colorString);
-
-    if (!colorString || !color) {
-      return;
-    }
-
-    const clrString = formatColor(color, this.colorStringFormat);
-    this._selectedColor.next(clrString);
-  }
-
-  /**
-   * Return internal selected color
-   */
-  getSelectedColor(): Observable<string> {
-    return this._selectedColor.asObservable();
   }
 }

--- a/src/lib/color-picker/color-picker.service.ts
+++ b/src/lib/color-picker/color-picker.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { EMPTY_COLOR, parseColorString, toRgba, USED_COLORS } from './color-picker';
+import { COLOR_STRING_FORMAT, ColorFormat, EMPTY_COLOR, formatColor, parseColorString, USED_COLORS } from './color-picker';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable()
@@ -7,7 +7,7 @@ export class MccColorPickerService {
   /**
    * Array of all used colors
    */
-  private _colors: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
+  private _usedColors: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
 
   /**
    * Hold current selected color
@@ -16,25 +16,37 @@ export class MccColorPickerService {
 
   constructor(
     @Inject(EMPTY_COLOR) private emptyColor: string,
-    @Inject(USED_COLORS) private usedColors: string[]
+    @Inject(USED_COLORS) private usedColors: string[],
+    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
   ) {
-    this._colors.next(usedColors);
+
+    // map color string from user to string based on configured format
+    const colors: string[] = [];
+    usedColors.forEach(value => {
+      const clr = parseColorString(value);
+      if (clr) {
+        colors.push(formatColor(clr, this.colorStringFormat));
+      }
+    });
+    this._usedColors.next(colors);
   }
 
   /**
    * Add new color to used colors
    */
   addColor(colorString: string) {
-    const color = toRgba(parseColorString(colorString));
+    const color = parseColorString(colorString);
 
     if (!colorString || !color) {
       return;
     }
 
-    const colors = this._colors.getValue();
-    if (!colors.includes(color) && !colors.includes(colorString)) { // checking rgba value and real string to prevent duplicates
-      colors.push(colorString);
-      this._colors.next(colors);
+    const clrString = formatColor(color, this.colorStringFormat);
+
+    const usedColors = this._usedColors.getValue();
+    if (!usedColors.includes(clrString)) {
+      usedColors.push(clrString);
+      this._usedColors.next(usedColors);
     }
   }
 
@@ -42,22 +54,28 @@ export class MccColorPickerService {
    * Return Observable of colors
    */
   getColors(): Observable<string[]> {
-    return this._colors.asObservable();
+    return this._usedColors.asObservable();
   }
 
   /**
    * Reset the array of used colors
    */
   resetUseColors(): void {
-    this._colors.next([]);
+    this._usedColors.next([]);
   }
 
   /**
    * Change internal selected color
-   * @param color
    */
-  changeSelectedColor(color: string) {
-    this._selectedColor.next(color);
+  changeSelectedColor(colorString: string) {
+    const color = parseColorString(colorString);
+
+    if (!colorString || !color) {
+      return;
+    }
+
+    const clrString = formatColor(color, this.colorStringFormat);
+    this._selectedColor.next(clrString);
   }
 
   /**

--- a/src/lib/color-picker/color-picker.service.ts
+++ b/src/lib/color-picker/color-picker.service.ts
@@ -17,7 +17,7 @@ export class MccColorPickerService {
   constructor(
     @Inject(EMPTY_COLOR) private emptyColor: string,
     @Inject(USED_COLORS) private usedColors: string[],
-    @Inject(COLOR_STRING_FORMAT) public colorStringFormat: ColorFormat
+    @Inject(COLOR_STRING_FORMAT) private colorStringFormat: ColorFormat
   ) {
 
     // map color string from user to string based on configured format

--- a/src/lib/color-picker/color-picker.service.ts
+++ b/src/lib/color-picker/color-picker.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
-import { COLOR_STRING_FORMAT, ColorFormat, EMPTY_COLOR, formatColor, parseColorString, USED_COLORS } from './color-picker';
+import { COLOR_STRING_FORMAT, ColorFormat, EMPTY_COLOR, USED_COLORS } from './color-picker.types';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { formatColor, parseColorString } from './color-picker.utils';
 
 @Injectable()
 export class MccColorPickerService {

--- a/src/lib/color-picker/color-picker.ts
+++ b/src/lib/color-picker/color-picker.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { tinycolor } from '@thebespokepixel/es-tinycolor';
-import type { Instance } from 'tinycolor2';
+import { Instance } from 'tinycolor2';
 
 
 

--- a/src/lib/color-picker/color-picker.ts
+++ b/src/lib/color-picker/color-picker.ts
@@ -3,7 +3,6 @@ import { tinycolor } from '@thebespokepixel/es-tinycolor';
 import { Instance } from 'tinycolor2';
 
 
-
 /** Contant used as empty color */
 export const EMPTY_COLOR = new InjectionToken<string>('empty-color');
 
@@ -22,6 +21,9 @@ export const DISABLE_SELECTED_COLOR_ICON = new InjectionToken<boolean>('disable-
 /** Enable alpha selector **/
 export const ENABLE_ALPHA_SELECTOR = new InjectionToken<boolean>('enable-alpha-selector');
 
+/** Format used for color strings **/
+export const COLOR_STRING_FORMAT = new InjectionToken<ColorFormat>('color-string-format');
+
 /**
  *
  */
@@ -32,6 +34,7 @@ export interface ColorPickerConfig {
   selected_svg_icon?: string;
   disable_selected_icon?: boolean;
   enable_alpha_selector?: boolean;
+  color_string_format?: string;
 }
 
 /**
@@ -48,6 +51,8 @@ export type MccColorPickerOption = string | MccColorPickerItem;
 
 export type MccColorPickerUsedColorPosition = 'top' | 'bottom';
 
+export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'hsv';
+
 /**
  * parses a string-representation of a color with tinycolor - returns "null" when not a valid string
  */
@@ -61,21 +66,65 @@ export function parseColorString(colorString: string): Instance | null {
 }
 
 /**
- * converts a tinycolor instance to format "#FFFFFF'
+ * converts a tinycolor instance to format "#FFFFFF' or "#FFFFFFFF" with alpha < 1
  */
 export function toHex(color: Instance): string {
   if (!color) {
     return null;
   }
-  return color.toString('hex6').toUpperCase();
+
+  if (color.getAlpha() < 1) {
+    return color.toHex8String().toUpperCase();
+  } else {
+    return color.toHexString().toUpperCase();
+  }
 }
 
 /**
- * converts a tinycolor instance to format "rgb(255,255,255)' when color has alpha value and "rgba(255,255,255,0.5)" when alpha < 1
+ * converts a tinycolor instance to format "rgb(255, 255, 255)" when color has no alpha value and "rgba(255, 255, 255, 0.5)" when alpha < 1
  */
-export function toRgba(color: Instance): string {
+export function toRgb(color: Instance): string {
   if (!color) {
     return null;
   }
   return color.toRgbString();
+}
+
+
+/**
+ * converts a tinycolor instance to format "hsl(360, 100%, 100%)" when color has no alpha value and "hsla(360, 100%, 100%, 0.5)" when alpha < 1
+ */
+export function toHsl(color: Instance): string {
+  if (!color) {
+    return null;
+  }
+  return color.toHslString();
+}
+
+
+/**
+ * converts a tinycolor instance to format "hsv(360, 100%, 100%)" when color has alpha value and "hsva(360, 100%, 100%, 0.5)" when alpha < 1
+ */
+export function toHsv(color: Instance): string {
+  if (!color) {
+    return null;
+  }
+  return color.toHsvString();
+}
+
+
+/**
+ * converts a tinycolor instance to certain format
+ */
+export function formatColor(color: Instance, format: ColorFormat): string {
+  switch (format) {
+    case 'hex':
+      return toHex(color);
+    case 'rgb':
+      return toRgb(color);
+    case 'hsl':
+      return toHsl(color);
+    case 'hsv':
+      return toHsv(color);
+  }
 }

--- a/src/lib/color-picker/color-picker.ts
+++ b/src/lib/color-picker/color-picker.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import { tinycolor } from '@thebespokepixel/es-tinycolor';
+import { TinyColor } from '@thebespokepixel/es-tinycolor';
 import { Instance } from 'tinycolor2';
 
 
@@ -53,11 +53,13 @@ export type MccColorPickerUsedColorPosition = 'top' | 'bottom';
 
 export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'hsv';
 
+export type Color = Instance;
+
 /**
  * parses a string-representation of a color with tinycolor - returns "null" when not a valid string
  */
-export function parseColorString(colorString: string): Instance | null {
-  const color: Instance = tinycolor(colorString);
+export function parseColorString(colorString: string): Color | null {
+  const color: Color = new TinyColor(colorString);
   if (color.isValid()) {
     return color;
   } else {
@@ -66,9 +68,9 @@ export function parseColorString(colorString: string): Instance | null {
 }
 
 /**
- * converts a tinycolor instance to format "#FFFFFF' or "#FFFFFFFF" with alpha < 1
+ * converts a TinyColor instance to format "#FFFFFF' or "#FFFFFFFF" with alpha < 1
  */
-export function toHex(color: Instance): string {
+export function toHex(color: Color): string {
   if (!color) {
     return null;
   }
@@ -81,9 +83,9 @@ export function toHex(color: Instance): string {
 }
 
 /**
- * converts a tinycolor instance to format "rgb(255, 255, 255)" when color has no alpha value and "rgba(255, 255, 255, 0.5)" when alpha < 1
+ * converts a TinyColor instance to format "rgb(255, 255, 255)" when color has no alpha value and "rgba(255, 255, 255, 0.5)" when alpha < 1
  */
-export function toRgb(color: Instance): string {
+export function toRgb(color: Color): string {
   if (!color) {
     return null;
   }
@@ -92,9 +94,9 @@ export function toRgb(color: Instance): string {
 
 
 /**
- * converts a tinycolor instance to format "hsl(360, 100%, 100%)" when color has no alpha value and "hsla(360, 100%, 100%, 0.5)" when alpha < 1
+ * converts a TinyColor instance to format "hsl(360, 100%, 100%)" when color has no alpha value and "hsla(360, 100%, 100%, 0.5)" when alpha < 1
  */
-export function toHsl(color: Instance): string {
+export function toHsl(color: Color): string {
   if (!color) {
     return null;
   }
@@ -103,9 +105,9 @@ export function toHsl(color: Instance): string {
 
 
 /**
- * converts a tinycolor instance to format "hsv(360, 100%, 100%)" when color has alpha value and "hsva(360, 100%, 100%, 0.5)" when alpha < 1
+ * converts a TinyColor instance to format "hsv(360, 100%, 100%)" when color has alpha value and "hsva(360, 100%, 100%, 0.5)" when alpha < 1
  */
-export function toHsv(color: Instance): string {
+export function toHsv(color: Color): string {
   if (!color) {
     return null;
   }
@@ -114,9 +116,9 @@ export function toHsv(color: Instance): string {
 
 
 /**
- * converts a tinycolor instance to certain format
+ * converts a TinyColor instance to certain format
  */
-export function formatColor(color: Instance, format: ColorFormat): string {
+export function formatColor(color: Color, format: ColorFormat): string {
   switch (format) {
     case 'hex':
       return toHex(color);

--- a/src/lib/color-picker/color-picker.ts
+++ b/src/lib/color-picker/color-picker.ts
@@ -21,7 +21,7 @@ export const DISABLE_SELECTED_COLOR_ICON = new InjectionToken<boolean>('disable-
 /** Enable alpha selector **/
 export const ENABLE_ALPHA_SELECTOR = new InjectionToken<boolean>('enable-alpha-selector');
 
-/** Format used for color strings **/
+/** Format used for color strings (can only be set on module-level, not on component-level) **/
 export const COLOR_STRING_FORMAT = new InjectionToken<ColorFormat>('color-string-format');
 
 /**

--- a/src/lib/color-picker/color-picker.types.ts
+++ b/src/lib/color-picker/color-picker.types.ts
@@ -1,0 +1,57 @@
+import { InjectionToken } from '@angular/core';
+import { Instance } from 'tinycolor2';
+
+
+/** Contant used as empty color */
+export const EMPTY_COLOR = new InjectionToken<string>('empty-color');
+
+/** Constante to set usedColorStart from the module import */
+export const USED_COLORS = new InjectionToken<string[]>('used-colors');
+
+/** Customize selected color icon */
+export const SELECTED_COLOR_ICON = new InjectionToken<string>('selected-color-icon');
+
+/** Customize selected color svg icon */
+export const SELECTED_COLOR_SVG_ICON = new InjectionToken<string>('selected-color-svg-icon');
+
+/** Disable selected color icon */
+export const DISABLE_SELECTED_COLOR_ICON = new InjectionToken<boolean>('disable-selected-color-icon');
+
+/** Enable alpha selector **/
+export const ENABLE_ALPHA_SELECTOR = new InjectionToken<boolean>('enable-alpha-selector');
+
+/** Format used for color strings (can only be set on module-level, not on component-level) **/
+export const COLOR_STRING_FORMAT = new InjectionToken<ColorFormat>('color-string-format');
+
+/**
+ *
+ */
+export interface ColorPickerConfig {
+  empty_color?: string;
+  used_colors?: string[];
+  selected_icon?: string;
+  selected_svg_icon?: string;
+  disable_selected_icon?: boolean;
+  enable_alpha_selector?: boolean;
+  color_string_format?: string;
+}
+
+/**
+ * This interface represents one color. Using this interface instead simple string
+ * will help screen readers, because the text attribute ir set to the aria-label of
+ * the option
+ */
+export interface MccColorPickerItem {
+  text: string;
+  value: string;
+}
+
+export type MccColorPickerOption = string | MccColorPickerItem;
+
+export type MccColorPickerUsedColorPosition = 'top' | 'bottom';
+
+export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'hsv';
+
+export type Color = Instance;
+
+

--- a/src/lib/color-picker/color-picker.utils.ts
+++ b/src/lib/color-picker/color-picker.utils.ts
@@ -1,59 +1,5 @@
-import { InjectionToken } from '@angular/core';
+import { Color, ColorFormat } from './color-picker.types';
 import { TinyColor } from '@thebespokepixel/es-tinycolor';
-import { Instance } from 'tinycolor2';
-
-
-/** Contant used as empty color */
-export const EMPTY_COLOR = new InjectionToken<string>('empty-color');
-
-/** Constante to set usedColorStart from the module import */
-export const USED_COLORS = new InjectionToken<string[]>('used-colors');
-
-/** Customize selected color icon */
-export const SELECTED_COLOR_ICON = new InjectionToken<string>('selected-color-icon');
-
-/** Customize selected color svg icon */
-export const SELECTED_COLOR_SVG_ICON = new InjectionToken<string>('selected-color-svg-icon');
-
-/** Disable selected color icon */
-export const DISABLE_SELECTED_COLOR_ICON = new InjectionToken<boolean>('disable-selected-color-icon');
-
-/** Enable alpha selector **/
-export const ENABLE_ALPHA_SELECTOR = new InjectionToken<boolean>('enable-alpha-selector');
-
-/** Format used for color strings (can only be set on module-level, not on component-level) **/
-export const COLOR_STRING_FORMAT = new InjectionToken<ColorFormat>('color-string-format');
-
-/**
- *
- */
-export interface ColorPickerConfig {
-  empty_color?: string;
-  used_colors?: string[];
-  selected_icon?: string;
-  selected_svg_icon?: string;
-  disable_selected_icon?: boolean;
-  enable_alpha_selector?: boolean;
-  color_string_format?: string;
-}
-
-/**
- * This interface represents one color. Using this interface instead simple string
- * will help screen readers, because the text attribute ir set to the aria-label of
- * the option
- */
-export interface MccColorPickerItem {
-  text: string;
-  value: string;
-}
-
-export type MccColorPickerOption = string | MccColorPickerItem;
-
-export type MccColorPickerUsedColorPosition = 'top' | 'bottom';
-
-export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'hsv';
-
-export type Color = Instance;
 
 /**
  * parses a string-representation of a color with tinycolor - returns "null" when not a valid string
@@ -92,7 +38,6 @@ export function toRgb(color: Color): string {
   return color.toRgbString();
 }
 
-
 /**
  * converts a TinyColor instance to format "hsl(360, 100%, 100%)" when color has no alpha value and "hsla(360, 100%, 100%, 0.5)" when alpha < 1
  */
@@ -103,7 +48,6 @@ export function toHsl(color: Color): string {
   return color.toHslString();
 }
 
-
 /**
  * converts a TinyColor instance to format "hsv(360, 100%, 100%)" when color has alpha value and "hsva(360, 100%, 100%, 0.5)" when alpha < 1
  */
@@ -113,7 +57,6 @@ export function toHsv(color: Color): string {
   }
   return color.toHsvString();
 }
-
 
 /**
  * converts a TinyColor instance to certain format

--- a/src/lib/color-picker/index.ts
+++ b/src/lib/color-picker/index.ts
@@ -1,1 +1,0 @@
-export * from './public_api';

--- a/src/lib/color-picker/public_api.ts
+++ b/src/lib/color-picker/public_api.ts
@@ -1,3 +1,3 @@
 export { MccColorPickerModule } from './color-picker.module';
 export { MccColorPickerService } from './color-picker.service';
-export { MccColorPickerItem, EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from './color-picker';
+export { MccColorPickerItem, EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from './color-picker.types';

--- a/src/lib/color-picker/public_api.ts
+++ b/src/lib/color-picker/public_api.ts
@@ -1,3 +1,12 @@
 export { MccColorPickerModule } from './color-picker.module';
 export { MccColorPickerService } from './color-picker.service';
-export { MccColorPickerItem, EMPTY_COLOR, ENABLE_ALPHA_SELECTOR } from './color-picker.types';
+export {
+  MccColorPickerItem,
+  EMPTY_COLOR,
+  ENABLE_ALPHA_SELECTOR,
+  COLOR_STRING_FORMAT,
+  DISABLE_SELECTED_COLOR_ICON,
+  SELECTED_COLOR_ICON,
+  SELECTED_COLOR_SVG_ICON,
+  USED_COLORS
+} from './color-picker.types';

--- a/src/lib/scrollspy/index.ts
+++ b/src/lib/scrollspy/index.ts
@@ -1,1 +1,0 @@
-export * from './public_api';

--- a/src/lib/speed-dial/index.ts
+++ b/src/lib/speed-dial/index.ts
@@ -1,1 +1,0 @@
-export * from './public_api';

--- a/src/lib/timer-picker/index.ts
+++ b/src/lib/timer-picker/index.ts
@@ -1,1 +1,0 @@
-export * from './public_api';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,5 +15,8 @@
     "paths": {
       "material-community-components": ["src/lib/*"]
     }
+  },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true
   }
 }


### PR DESCRIPTION
Implementing https://github.com/tiaguinho/material-community-components/issues/140 

Format is only for Output of the color-picker and internal string representations.

As Inputs (selectedColor, addColor, USED_COLORS) ALL formats supported by tinycolor are supported (https://github.com/thebespokepixel/es-tinycolor/blob/master/readme.md). They are then normalized to the selected COLOR_STRING_FORMAT internaly.