### PR TITLE
Fixes the bug where the selected color in the color picker remains transparent when the alpha channel is disabled and the empty_color is transparent. Resolves #212

### DIFF
--- a/projects/material-community-components/color-picker/color-picker-selector.component.ts
+++ b/projects/material-community-components/color-picker/color-picker-selector.component.ts
@@ -235,6 +235,10 @@ export class MccColorPickerSelectorComponent implements AfterViewInit, OnInit, O
     this._tmpSelectedColor.next(this._selectedColor);
 
     this._tmpSelectedColorSub = this._tmpSelectedColor.subscribe(color => {
+      if (!this.colorPickerCollectionService.alpha) {
+        color.setAlpha(1);
+      }
+
       this.textClass = color.isDark() && color.getAlpha() > 0.3 ? 'white' : 'black';
       // right now using hex for non alpha and rgba for alpha colors
       if (this.noColor) {

--- a/projects/material-community-components/color-picker/color-picker-selector.component.ts
+++ b/projects/material-community-components/color-picker/color-picker-selector.component.ts
@@ -21,6 +21,7 @@ import { TinyColor } from '@thebespokepixel/es-tinycolor';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { MccColorPickerCollectionService } from './color-picker-collection.service';
 import { formatColor, parseColorString, toHex, toRgb } from './color-picker.utils';
+import * as tinycolor from 'tinycolor2';
 
 interface Coordinates {
   x: number;
@@ -234,8 +235,9 @@ export class MccColorPickerSelectorComponent implements AfterViewInit, OnInit, O
     // set selectedColor initial value
     this._tmpSelectedColor.next(this._selectedColor);
 
+    let previousColor: TinyColor | undefined;
     this._tmpSelectedColorSub = this._tmpSelectedColor.subscribe(color => {
-      if (!this.colorPickerCollectionService.alpha) {
+      if (!this.colorPickerCollectionService.alpha && previousColor?.getAlpha() === 0) {
         color.setAlpha(1);
       }
 
@@ -249,6 +251,8 @@ export class MccColorPickerSelectorComponent implements AfterViewInit, OnInit, O
         this.changeSelectedColor.emit(clr);
         this.colorPickerCollectionService.changeSelectedColor(clr);
       }
+
+      previousColor = color;
     });
 
     // hex form


### PR DESCRIPTION
The problem is explained in more detail in issue #212.

This change makes the selected color in the color picker opaque by setting the alpha value to 1 when the alpha channel is disabled.
Note: It is still possible to change back to the transparent `empty_color`, as expected.